### PR TITLE
Add support for datacenter classes in extractor and builder

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,8 @@
   "editor.formatOnSave": false,
   "[typescript]": {
       "editor.formatOnSave": true
+  },
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": false
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cookiebuilder",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "Dofus Protocol Builder",
   "main": "dist/Library.js",
   "types": "dist/Library.d.ts",

--- a/src/builder/dataCenters.ts
+++ b/src/builder/dataCenters.ts
@@ -1,0 +1,88 @@
+import { IProtocol } from "@/extractor";
+import { ID2Class } from "@/extractor/classes";
+import { writeFileSync } from "fs";
+import { join } from "path";
+import {
+  cleanNamespace,
+  getDefaultInitValue,
+  getRealType,
+  mkdirRecursive
+} from "./utils";
+
+export function buildDataCenters(protocol: IProtocol, path: string) {
+  for (const m of protocol.dataCenters) {
+    const clean = cleanNamespace(m.package);
+
+    const folderPath = join(path, clean);
+    mkdirRecursive(folderPath);
+
+    const importsFile: string[] = [];
+
+    if (m.parent !== "") {
+      const parent = protocol.dataCenters.find(ty => ty.name === m.parent);
+      if (!parent) {
+        console.log(`${m.parent} not found.`);
+      } else {
+        const cleanNs = cleanNamespace(parent.package);
+        importsFile.push(
+          `import { ${m.parent} } from "@${cleanNs}/${m.parent}";`
+        );
+      }
+    }
+
+    const head = [
+      `export class ${m.name} ${m.parent !== "" ? `extends ${m.parent} ` : ""}{`
+    ];
+
+    const bottom = ["}\n"];
+
+    const body = buildDataCenter(protocol, m, importsFile);
+    const all = importsFile.concat([""], head, body, bottom).join("\n");
+
+    const filePath = join(folderPath, `${m.name}.ts`);
+    // console.log(`Writing DataCenter: ${filePath} ...`);
+    writeFileSync(filePath, all);
+  }
+}
+
+function buildDataCenter(
+  protocol: IProtocol,
+  m: ID2Class,
+  imports: string[]
+): string[] {
+  const data: string[] = [];
+  const usedImports: Map<string, string> = new Map();
+
+  for (const o of m.fields) {
+    let realType = getRealType(o.type);
+    let initValue = getDefaultInitValue(realType);
+    const isCustomType = realType === "";
+    if (isCustomType) {
+      const alreadyImported = usedImports.has(o.type);
+      if (!alreadyImported) {
+        const type = protocol.dataCenters.find(ty => ty.name === o.type);
+        if (!type) {
+          console.log(`${o.type} not found.`);
+        } else {
+          const cleanNs = cleanNamespace(type.package);
+
+          imports.push(`import { ${o.type} } from "@${cleanNs}/${o.type}";`);
+          usedImports.set(o.type, "ALREADY");
+        }
+      }
+      realType = o.type;
+      initValue = `new ${o.type}()`;
+    }
+    if (o.isVector) {
+      realType += "[]";
+      initValue = "[]";
+    }
+    if (o.isVectorVector) {
+      realType += "[][]";
+      initValue = "[]";
+    }
+    data.push(`  public ${o.name}: ${realType} = ${initValue};`);
+  }
+
+  return data;
+}

--- a/src/builder/index.ts
+++ b/src/builder/index.ts
@@ -1,4 +1,5 @@
 import { IProtocol } from "@/extractor";
+import { buildDataCenters } from "./dataCenters";
 import { buildEnums } from "./enums";
 import { buildMessages } from "./messages";
 import { buildMetadata } from "./metadata";
@@ -11,6 +12,7 @@ export function build(protocol: IProtocol, path: string) {
   mkdirRecursive(path);
   buildTypes(protocol, path);
   buildMessages(protocol, path);
+  buildDataCenters(protocol, path);
   buildEnums(protocol.enums, path);
   buildMetadata(protocol.metadata, path);
   buildProtocolConstantsEnum(protocol.protocolConstantsEnum, path);

--- a/src/builder/messages.ts
+++ b/src/builder/messages.ts
@@ -64,7 +64,7 @@ export function buildMessages(protocol: IProtocol, path: string) {
 
     const head = [
       `export class ${m.name} ${
-        m.parent !== "" ? `extends ${m.parent}` : "extends NetworkMessage"
+      m.parent !== "" ? `extends ${m.parent}` : "extends NetworkMessage"
       } implements INetworkMessage {`
     ];
 
@@ -129,7 +129,7 @@ function buildMessage(
       resetBody.push(`    this.${b.name} = false;`);
       serializeBody.push(
         `    b = BooleanByteWrapper.setFlag(b, ${b.bbwPosition}, this.${
-          b.name
+        b.name
         });`
       );
       deserializeBody.push(
@@ -160,6 +160,10 @@ function buildMessage(
     }
     if (o.isVector) {
       realType += "[]";
+      initValue = "[]";
+    }
+    if (o.isVectorVector) {
+      realType += "[][]";
       initValue = "[]";
     }
     data.push(`  public ${o.name}: ${realType} = ${initValue};`);
@@ -204,10 +208,10 @@ function buildMessage(
           );
           deserializeBody.push(
             `    for (let i = 0; i < ${
-              o.length ? o.length : `${o.name}Length`
+            o.length ? o.length : `${o.name}Length`
             }; i++) {`,
             `      const e = ProtocolTypeManager.getInstance(reader.readUnsignedShort()) as ${
-              o.type
+            o.type
             };`,
             `      e.deserialize(reader);`,
             `      this.${o.name}.push(e);`,
@@ -221,7 +225,7 @@ function buildMessage(
           );
           deserializeBody.push(
             `    for (let i = 0; i < ${
-              o.length ? o.length : `${o.name}Length`
+            o.length ? o.length : `${o.name}Length`
             }; i++) {`,
             `      const e = new ${o.type}();`,
             `      e.deserialize(reader);`,
@@ -237,10 +241,10 @@ function buildMessage(
         );
         deserializeBody.push(
           `    for (let i = 0; i < ${
-            o.length ? o.length : `${o.name}Length`
+          o.length ? o.length : `${o.name}Length`
           }; i++) {`,
           `      this.${o.name}.push(reader.${o.writeMethod &&
-            o.writeMethod.replace("write", "read")}());`,
+          o.writeMethod.replace("write", "read")}());`,
           `    }`
         );
       }
@@ -252,9 +256,9 @@ function buildMessage(
         serializeBody.push(`    this.${o.name}.serialize(writer);`);
         deserializeBody.push(
           `    this.${
-            o.name
+          o.name
           } = ProtocolTypeManager.getInstance(reader.readUnsignedShort()) as ${
-            o.type
+          o.type
           };`
         );
         deserializeBody.push(`    this.${o.name}.deserialize(reader);`);
@@ -267,9 +271,9 @@ function buildMessage(
           serializeBody.push(`    writer.${o.writeMethod}(this.${o.name});`);
           deserializeBody.push(
             `    this.${o.name} = reader.${
-              o.writeMethod
-                ? o.writeMethod.replace("write", "read")
-                : `${o.method}`
+            o.writeMethod
+              ? o.writeMethod.replace("write", "read")
+              : `${o.method}`
             }();`
           );
         }

--- a/src/builder/types.ts
+++ b/src/builder/types.ts
@@ -53,7 +53,7 @@ export function buildTypes(protocol: IProtocol, path: string) {
 
     const head = [
       `export class ${t.name} ${
-        t.parent !== "" ? `extends ${t.parent} ` : ""
+      t.parent !== "" ? `extends ${t.parent} ` : ""
       }implements INetworkType {`
     ];
 
@@ -118,7 +118,7 @@ function buildType(
       resetBody.push(`    this.${b.name} = false;`);
       serializeBody.push(
         `    b = BooleanByteWrapper.setFlag(b, ${b.bbwPosition}, this.${
-          b.name
+        b.name
         });`
       );
       deserializeBody.push(
@@ -149,6 +149,10 @@ function buildType(
     }
     if (o.isVector) {
       realType += "[]";
+      initValue = "[]";
+    }
+    if (o.isVectorVector) {
+      realType += "[][]";
       initValue = "[]";
     }
     data.push(`  public ${o.name}: ${realType} = ${initValue};`);
@@ -193,10 +197,10 @@ function buildType(
           );
           deserializeBody.push(
             `    for (let i = 0; i < ${
-              o.length ? o.length : `${o.name}Length`
+            o.length ? o.length : `${o.name}Length`
             }; i++) {`,
             `      const e = ProtocolTypeManager.getInstance(reader.readUnsignedShort()) as ${
-              o.type
+            o.type
             };`,
             `      e.deserialize(reader);`,
             `      this.${o.name}.push(e);`,
@@ -210,7 +214,7 @@ function buildType(
           );
           deserializeBody.push(
             `    for (let i = 0; i < ${
-              o.length ? o.length : `${o.name}Length`
+            o.length ? o.length : `${o.name}Length`
             }; i++) {`,
             `      const e = new ${o.type}();`,
             `      e.deserialize(reader);`,
@@ -226,10 +230,10 @@ function buildType(
         );
         deserializeBody.push(
           `    for (let i = 0; i < ${
-            o.length ? o.length : `${o.name}Length`
+          o.length ? o.length : `${o.name}Length`
           }; i++) {`,
           `      this.${o.name}.push(reader.${o.writeMethod &&
-            o.writeMethod.replace("write", "read")}());`,
+          o.writeMethod.replace("write", "read")}());`,
           `    }`
         );
       }
@@ -241,9 +245,9 @@ function buildType(
         serializeBody.push(`    this.${o.name}.serialize(writer);`);
         deserializeBody.push(
           `    this.${
-            o.name
+          o.name
           } = ProtocolTypeManager.getInstance(reader.readUnsignedShort()) as ${
-            o.type
+          o.type
           };`
         );
         deserializeBody.push(`    this.${o.name}.deserialize(reader);`);
@@ -256,9 +260,9 @@ function buildType(
           serializeBody.push(`    writer.${o.writeMethod}(this.${o.name});`);
           deserializeBody.push(
             `    this.${o.name} = reader.${
-              o.writeMethod
-                ? o.writeMethod.replace("write", "read")
-                : `${o.method}`
+            o.writeMethod
+              ? o.writeMethod.replace("write", "read")
+              : `${o.method}`
             }();`
           );
         }

--- a/src/extractor/classes/reducers.ts
+++ b/src/extractor/classes/reducers.ts
@@ -14,20 +14,31 @@ const writeMethodTypesMap = new Map([
   ["writeUTF", "string"]
 ]);
 
+const typesMap = new Map([
+  ["int", "int32"],
+  ["uint", "uint32"],
+  ["Number", "float32"],
+  ["String", "string"],
+  ["Object", "uint32"]
+]);
+
 export function reduceType(f: ID2ClassField) {
   if (f.type === "Boolean") {
     f.type = "bool";
   }
-  if (!f.writeMethod || f.writeMethod === "") {
-    return;
-  } else if (f.writeMethod === "writeBytes") {
-    // hack to get NetworkDataContainerMessage working
-    f.isVector = true;
-    f.isDynamicLength = true;
-    f.writeLengthMethod = "writeVarInt";
-    f.writeMethod = "writeByte";
+  let reduced: string | undefined;
+  if (f.writeMethod && f.writeMethod !== "") {
+    if (f.writeMethod === "writeBytes") {
+      // hack to get NetworkDataContainerMessage working
+      f.isVector = true;
+      f.isDynamicLength = true;
+      f.writeLengthMethod = "writeVarInt";
+      f.writeMethod = "writeByte";
+    }
+    reduced = writeMethodTypesMap.get(f.writeMethod);
+  } else {
+    reduced = typesMap.get(f.type);
   }
-  let reduced = writeMethodTypesMap.get(f.writeMethod);
   if (reduced) {
     // Sometimes, unsigned variables are written with signed functions
     if (f.type === "uint" && reduced.startsWith("int")) {

--- a/src/extractor/classes/utils.ts
+++ b/src/extractor/classes/utils.ts
@@ -8,6 +8,7 @@ import {
   NamespaceKind
 } from "xswf/dist/abcFile/types/namespace";
 import { Trait, TraitKind } from "xswf/dist/abcFile/types/trait";
+import { ID2Class } from ".";
 
 export function findMethodWithPrefix(
   c: IClassInfo,
@@ -48,4 +49,109 @@ export function isAs3ScalarType(t: string): boolean {
     }
   }
   return false;
+}
+
+export function generateFlashGeomClasses(packageName: string): ID2Class[] {
+  const classesList: ID2Class[] = [];
+
+  classesList.push({
+    fields: [
+      {
+        isVector: false,
+        isVectorVector: false,
+        name: "x",
+        type: "int32"
+      },
+      {
+        isVector: false,
+        isVectorVector: false,
+        name: "y",
+        type: "int32"
+      },
+      {
+        isVector: false,
+        isVectorVector: false,
+        name: "length",
+        type: "float32"
+      }
+    ],
+    name: "Point",
+    package: packageName,
+    parent: ""
+  });
+  classesList.push({
+    fields: [
+      {
+        isVector: false,
+        isVectorVector: false,
+        name: "x",
+        type: "int32"
+      },
+      {
+        isVector: false,
+        isVectorVector: false,
+        name: "y",
+        type: "int32"
+      },
+      {
+        isVector: false,
+        isVectorVector: false,
+        name: "width",
+        type: "int32"
+      },
+      {
+        isVector: false,
+        isVectorVector: false,
+        name: "height",
+        type: "int32"
+      },
+      {
+        isVector: false,
+        isVectorVector: false,
+        name: "top",
+        type: "int32"
+      },
+      {
+        isVector: false,
+        isVectorVector: false,
+        name: "right",
+        type: "int32"
+      },
+      {
+        isVector: false,
+        isVectorVector: false,
+        name: "left",
+        type: "int32"
+      },
+      {
+        isVector: false,
+        isVectorVector: false,
+        name: "bottom",
+        type: "int32"
+      },
+      {
+        isVector: false,
+        isVectorVector: false,
+        name: "bottomRight",
+        type: "Point"
+      },
+      {
+        isVector: false,
+        isVectorVector: false,
+        name: "topLeft",
+        type: "Point"
+      },
+      {
+        isVector: false,
+        isVectorVector: false,
+        name: "size",
+        type: "Point"
+      },
+    ],
+    name: "Rectangle",
+    package: packageName,
+    parent: ""
+  });
+
+  return classesList;
 }

--- a/src/extractor/index.ts
+++ b/src/extractor/index.ts
@@ -1,27 +1,29 @@
 import { IAbcFile } from "xswf/dist/abcFile/types";
-import { extractD2MessagesAndTypes, ID2Class } from "./classes";
+import { extractD2DataCenters, extractD2MessagesAndTypes, ID2Class } from "./classes";
 import { extractD2Enums, ID2Enum } from "./enums";
 import { extractMetadata, IMetadata } from "./metadata";
 import { extractProtocolConstantsEnum } from "./protocolConstantsEnum";
 import { extractVersion, IVersion } from "./version";
 
 export interface IProtocol {
-  metadata: IMetadata;
-  version: IVersion;
+  dataCenters: ID2Class[];
   enums: ID2Enum[];
-  protocolConstantsEnum: ID2Enum;
   messages: ID2Class[];
+  metadata: IMetadata;
+  protocolConstantsEnum: ID2Enum;
   types: ID2Class[];
+  version: IVersion;
 }
 
 export function extract(abcFile: IAbcFile): IProtocol {
   const { messages, types } = extractD2MessagesAndTypes(abcFile);
   return {
+    dataCenters: extractD2DataCenters(abcFile),
     enums: extractD2Enums(abcFile),
     messages,
     metadata: extractMetadata(abcFile)!,
     protocolConstantsEnum: extractProtocolConstantsEnum(abcFile),
     types,
-    version: extractVersion(abcFile)
+    version: extractVersion(abcFile),
   };
 }

--- a/tests/main.spec.ts
+++ b/tests/main.spec.ts
@@ -11,7 +11,7 @@ describe("Main Tests", () => {
     protocol = await CookieBuilder.extract()!;
   });
 
-  it("instanciates the class", () => {
+  it("instantiates the class", () => {
     const result = expect(builder).not.undefined;
   });
 
@@ -30,14 +30,14 @@ describe("Main Tests", () => {
   });
 
   it("should have enums", () => {
-    const result = expect(protocol.enums.length).to.equal(94);
+    const result = expect(protocol.enums.length).to.equal(87);
   });
 
   it("should have messages", () => {
-    const result = expect(protocol.messages.length).to.equal(1054);
+    const result = expect(protocol.messages.length).to.equal(1059);
   });
 
   it("should have types", () => {
-    const result = expect(protocol.types.length).to.equal(307);
+    const result = expect(protocol.types.length).to.equal(309);
   });
 });


### PR DESCRIPTION
I had time left and nothing special to do, so I added support for datacenter classes in extractor and builder, along with other minor fixes/changes.

- Fix specs (don't know why they were failing)
- Add a little entry to the VSCode settings to avoid organizing imports on save
- Add support for datacenter classes in extractor
- Add support for datacenter classes in builder